### PR TITLE
Update constants

### DIFF
--- a/packages/charted/lib/charts/data_transformers/aggregation.dart
+++ b/packages/charted/lib/charts/data_transformers/aggregation.dart
@@ -312,7 +312,7 @@ class AggregationModel {
         for (int fi = 0; fi < factsCount; fi++) {
           var value = factsAccessor(item, _factFields[fi]);
           _factsCache[factsDataOffset + fi] =
-              (value == null) ? double.NAN : (value as num).toDouble();
+              (value == null) ? double.nan : (value as num).toDouble();
         }
       }
 

--- a/packages/charted/lib/charts/layout_renderers/pie_chart_renderer.dart
+++ b/packages/charted/lib/charts/layout_renderers/pie_chart_renderer.dart
@@ -161,7 +161,7 @@ class PieChartRenderer extends LayoutRendererBase {
           label: row.elementAt(dimension) as String,
           series: [series],
           value:
-              '${(((d.endAngle - d.startAngle) * 50) / math.PI).toStringAsFixed(2)}%');
+              '${(((d.endAngle - d.startAngle) * 50) / math.pi).toStringAsFixed(2)}%');
     });
     return _legend..addAll(area.config.isRTL ? items.reversed : items);
   }

--- a/packages/charted/lib/core/interpolators/easing.dart
+++ b/packages/charted/lib/core/interpolators/easing.dart
@@ -55,9 +55,9 @@ EasingFunction reflectReverseEasingFn(EasingFunction f) =>
 EasingFunction easePoly([num e = 1]) => (t) => math.pow(t, e);
 
 EasingFunction easeElastic([num a = 1, num p = 0.45]) {
-  num s = p / 2 * math.PI * math.asin(1 / a);
+  num s = p / 2 * math.pi * math.asin(1 / a);
   return (t) =>
-      1 + a * math.pow(2, -10 * t) * math.sin((t - s) * 2 * math.PI / p);
+      1 + a * math.pow(2, -10 * t) * math.sin((t - s) * 2 * math.pi / p);
 }
 
 EasingFunction easeBack([num s = 1.70158]) =>
@@ -74,7 +74,7 @@ EasingFunction easeCubicInOut() => (num t) {
       return 4 * (t < .5 ? t3 : 3 * (t - t2) + t3 - .75);
     };
 
-EasingFunction easeSin() => (num t) => 1 - math.cos(t * math.PI / 2);
+EasingFunction easeSin() => (num t) => 1 - math.cos(t * math.pi / 2);
 
 EasingFunction easeExp() => (num t) => math.pow(2, 10 * (t - 1));
 

--- a/packages/charted/lib/core/interpolators/interpolators.dart
+++ b/packages/charted/lib/core/interpolators/interpolators.dart
@@ -335,7 +335,7 @@ Interpolator<List<num>> createZoomInterpolator(List a, List b) {
   if (a == null || b == null) return (t) => b;
   assert(a.length == b.length && a.length == 3);
 
-  var sqrt2 = math.SQRT2, param2 = 2, param4 = 4;
+  var sqrt2 = math.sqrt2, param2 = 2, param4 = 4;
 
   num ux0 = a[0], uy0 = a[1], w0 = a[2], ux1 = b[0], uy1 = b[1], w1 = b[2];
 

--- a/packages/charted/lib/core/scales/linear_scale.dart
+++ b/packages/charted/lib/core/scales/linear_scale.dart
@@ -178,20 +178,20 @@ abstract class BaseLinearScale implements Scale<num, num> {
           ? 1
           : math.pow(
               10,
-              (math.log(extent.max.abs() / forcedTicksCount) / math.LN10)
+              (math.log(extent.max.abs() / forcedTicksCount) / math.ln10)
                   .floor());
       num max = (extent.max / maxFactor).ceil() * maxFactor;
       num minFactor = extent.min == 0
           ? 1
           : math.pow(
               10,
-              (math.log(extent.min.abs() / forcedTicksCount) / math.LN10)
+              (math.log(extent.min.abs() / forcedTicksCount) / math.ln10)
                   .floor());
       num min = (extent.min / minFactor).floor() * minFactor;
       step = (max - min) / forcedTicksCount;
       return new Range(min, max + step * 0.5, step);
     } else {
-      step = math.pow(10, (math.log(span / _ticksCount) / math.LN10).floor());
+      step = math.pow(10, (math.log(span / _ticksCount) / math.ln10).floor());
       var err = _ticksCount / span * step;
 
       // Filter ticks to get closer to the desired count.
@@ -212,7 +212,7 @@ abstract class BaseLinearScale implements Scale<num, num> {
   FormatFunction createTickFormatter([String formatStr]) {
     if (formatStr == null) {
       int precision(num value) {
-        return -(math.log(value) / math.LN10 + .01).floor();
+        return -(math.log(value) / math.ln10 + .01).floor();
       }
 
       Range tickRange = _linearTickRange();

--- a/packages/charted/lib/core/utils/math.dart
+++ b/packages/charted/lib/core/utils/math.dart
@@ -9,14 +9,14 @@
 part of charted.core.utils;
 
 /// Mathematical constant PI
-const double PI = math.PI;
+const double pi = math.pi;
 
 /// PI * 0.5
-const double HALF_PI = PI / 2.0;
+const double HALF_PI = pi / 2.0;
 
 /// PI * 2
 /// Ratio constant of a circle's circumference to radius
-const double TAU = PI * 2.0;
+const double TAU = pi * 2.0;
 
 /// An arbitrary small possible number
 const double EPSILON = 1e-6;
@@ -42,7 +42,7 @@ num sinh(num x) => ((x = math.exp(x)) - 1 / x) / 2;
 num tanh(num x) => ((x = math.exp(2 * x)) - 1) / (x + 1);
 
 /// Converts [degrees] to radians.
-num toRadians(num degrees) => degrees * math.PI / 180.0;
+num toRadians(num degrees) => degrees * math.pi / 180.0;
 
 /// Converts [radians] to degrees.
-num toDegrees(num radians) => radians * 180.0 / math.PI;
+num toDegrees(num radians) => radians * 180.0 / math.pi;

--- a/packages/charted/lib/layout/src/pie_layout.dart
+++ b/packages/charted/lib/layout/src/pie_layout.dart
@@ -84,5 +84,5 @@ class PieLayout {
   static num defaultStartAngleCallback(d, i, _) => 0;
 
   /** Default end angle callback - returns 2 * PI */
-  static num defaultEndAngleCallback(d, i, _) => 2 * PI;
+  static num defaultEndAngleCallback(d, i, _) => 2 * pi;
 }

--- a/packages/charted/lib/layout/src/treemap_layout.dart
+++ b/packages/charted/lib/layout/src/treemap_layout.dart
@@ -138,7 +138,7 @@ class TreeMapLayout extends HierarchyLayout<TreeMapNode> {
 
   /// Computes the most amount of area needed to layout the list of nodes.
   num _worst(List<TreeMapNode> nodes, num length, num pArea) {
-    num area, rmax = 0, rmin = double.INFINITY;
+    num area, rmax = 0, rmin = double.infinity;
     for (var node in nodes) {
       area = node.area;
       if (area <= 0) continue;
@@ -150,7 +150,7 @@ class TreeMapLayout extends HierarchyLayout<TreeMapNode> {
     return (pArea > 0)
         ? math.max(
             length * rmax * ratio / pArea, pArea / (length * rmin * ratio))
-        : double.INFINITY;
+        : double.infinity;
   }
 
   /// Recursively compute each nodes (and its children nodes) position and size
@@ -164,7 +164,7 @@ class TreeMapLayout extends HierarchyLayout<TreeMapNode> {
       var remaining = new List<TreeMapNode>.from(children);
       int n;
       num score,
-          best = double.INFINITY,
+          best = double.infinity,
           length = (mode == TREEMAP_LAYOUT_SLICE)
               ? rect.width
               : (mode == TREEMAP_LAYOUT_DICE)
@@ -187,7 +187,7 @@ class TreeMapLayout extends HierarchyLayout<TreeMapNode> {
           length = math.min(rect.width, rect.height);
           nodes.clear();
           area = 0;
-          best = double.INFINITY;
+          best = double.infinity;
         }
       }
       if (nodes.isNotEmpty) {

--- a/packages/charted/lib/locale/format.dart
+++ b/packages/charted/lib/locale/format.dart
@@ -71,7 +71,7 @@ class FormatPrefix {
     }
 
     // Determining SI scale of the value in increment of 1000.
-    i = 1 + (1e-12 + math.log(value) / math.LN10).floor();
+    i = 1 + (1e-12 + math.log(value) / math.ln10).floor();
     i = math.max(-24, math.min(24, ((i - 1) / 3).floor() * 3));
     i = 8 + (i / 3).floor();
 
@@ -82,7 +82,7 @@ class FormatPrefix {
   }
 
   num _formatPrecision(num x, num p) {
-    return p - (x != 0 ? (math.log(x) / math.LN10).ceil() : 1);
+    return p - (x != 0 ? (math.log(x) / math.ln10).ceil() : 1);
   }
 
   /** Returns the value of x rounded to the nth digit. */

--- a/packages/charted/lib/svg/shapes/arc.dart
+++ b/packages/charted/lib/svg/shapes/arc.dart
@@ -67,7 +67,7 @@ class SvgArc implements SvgShape {
         se = math.sin(ea),
         cs = math.cos(sa),
         ce = math.cos(ea),
-        df = delta < PI ? 0 : 1;
+        df = delta < pi ? 0 : 1;
 
     return ir > 0
         ? "M${or * cs},${or * ss}"
@@ -84,7 +84,7 @@ class SvgArc implements SvgShape {
   List centroid(d, int i, Element e) {
     var r = (innerRadiusCallback(d, i, e) + outerRadiusCallback(d, i, e)) / 2,
         a = (startAngleCallback(d, i, e) + endAngleCallback(d, i, e)) / 2 -
-            math.PI / 2;
+            math.pi / 2;
     return [math.cos(a) * r, math.sin(a) * r];
   }
 

--- a/packages/charted/test.disabled/core/math_test.dart
+++ b/packages/charted/test.disabled/core/math_test.dart
@@ -11,20 +11,20 @@ part of charted.test.core;
 testMath() {
   test('toRadius() correctly converts degrees to radians', () {
     expect(toRadians(0), equals(0));
-    expect(toRadians(180), equals(math.PI));
-    expect(toRadians(360), equals(math.PI * 2));
-    expect(toRadians(90), equals(math.PI / 2));
-    expect(toRadians(30), equals(math.PI / 6));
-    expect(toRadians(45), equals(math.PI / 4));
+    expect(toRadians(180), equals(math.pi));
+    expect(toRadians(360), equals(math.pi * 2));
+    expect(toRadians(90), equals(math.pi / 2));
+    expect(toRadians(30), equals(math.pi / 6));
+    expect(toRadians(45), equals(math.pi / 4));
   });
 
   test('toDegrees() correctly converts radians to degrees', () {
     expect(toDegrees(0), closeTo(0, EPSILON));
-    expect(toDegrees(math.PI), closeTo(180, EPSILON));
-    expect(toDegrees(math.PI * 2), closeTo(360, EPSILON));
-    expect(toDegrees(math.PI / 2), closeTo(90, EPSILON));
-    expect(toDegrees(math.PI / 6), closeTo(30, EPSILON));
-    expect(toDegrees(math.PI / 4), closeTo(45, EPSILON));
+    expect(toDegrees(math.pi), closeTo(180, EPSILON));
+    expect(toDegrees(math.pi * 2), closeTo(360, EPSILON));
+    expect(toDegrees(math.pi / 2), closeTo(90, EPSILON));
+    expect(toDegrees(math.pi / 6), closeTo(30, EPSILON));
+    expect(toDegrees(math.pi / 4), closeTo(45, EPSILON));
   });
 
   test('sinh() correctly calculates sinh', () {

--- a/packages/charted/test.disabled/layout/pie_layout_test.dart
+++ b/packages/charted/test.disabled/layout/pie_layout_test.dart
@@ -16,10 +16,10 @@ testPieLayout() {
     [10, 5, 5],       // Case for sorting, results the same as the first case.
   ];
   List mockPieAngle = [
-    [[0, PI / 2], [PI / 2, PI], [PI, PI * 2]],
+    [[0, pi / 2], [pi / 2, pi], [pi, pi * 2]],
     [[0, 0], [0, 0]],
-    [[0, 2 * PI]],
-    [[0, PI / 2], [PI / 2, PI], [PI, PI * 2]],
+    [[0, 2 * pi]],
+    [[0, pi / 2], [pi / 2, pi], [pi, pi * 2]],
   ];
 
   group('PieLayout.startAngleCallback', () {
@@ -37,7 +37,7 @@ testPieLayout() {
   group('PieLayout.endAngleCallback', () {
     PieLayout pieLayout = new PieLayout();
     test('= 2 * PI by default', () {
-      expect(pieLayout.endAngleCallback(null, 0, null), equals(2 * PI));
+      expect(pieLayout.endAngleCallback(null, 0, null), equals(2 * pi));
     });
     PieLayout pieLayout2 = new PieLayout();
     pieLayout2.endAngle = 0.4;

--- a/packages/charted/test.disabled/svg/svg_arc_test.dart
+++ b/packages/charted/test.disabled/svg/svg_arc_test.dart
@@ -13,12 +13,12 @@ testSvgArc() {
   List mockSvgData = [
     new SvgArcData(null, 0, 0,      0,      0,  100),  // Init sector
     new SvgArcData(null, 0, 0,      0,      50, 100),  // Init donut
-    new SvgArcData(null, 0, 0,      2 * PI, 0,  100),  // Whole sector
-    new SvgArcData(null, 0, 0,      2 * PI, 50, 100),  // Whole donut
-    new SvgArcData(null, 0, 0,      PI / 3, 0,  100),  // Sector start angle 0
-    new SvgArcData(null, 0, 0,      PI / 3, 50, 100),  // Slice start angle 0
-    new SvgArcData(null, 0, PI / 3, PI,     0,  100),  // Sector start angle > 0
-    new SvgArcData(null, 0, PI / 3, PI,     50, 100),  // Slice start angle > 0
+    new SvgArcData(null, 0, 0,      2 * pi, 0,  100),  // Whole sector
+    new SvgArcData(null, 0, 0,      2 * pi, 50, 100),  // Whole donut
+    new SvgArcData(null, 0, 0,      pi / 3, 0,  100),  // Sector start angle 0
+    new SvgArcData(null, 0, 0,      pi / 3, 50, 100),  // Slice start angle 0
+    new SvgArcData(null, 0, pi / 3, pi,     0,  100),  // Sector start angle > 0
+    new SvgArcData(null, 0, pi / 3, pi,     50, 100),  // Slice start angle > 0
   ];
 
   test('interpolateSvgArcData() returns an InterpolateFn that '

--- a/packages/quiver/lib/io.dart
+++ b/packages/quiver/lib/io.dart
@@ -20,7 +20,7 @@ import 'dart:io';
 
 ///  Converts a [Stream] of byte lists to a [String].
 Future<String> byteStreamToString(Stream<List<int>> stream,
-    {Encoding encoding: UTF8}) {
+    {Encoding encoding: utf8}) {
   return stream.transform(encoding.decoder).join();
 }
 
@@ -47,7 +47,7 @@ Future visitDirectory(Directory dir, Future<bool> visit(FileSystemEntity f)) {
           if (entity is! File && recurse == true) {
             if (entity is Link) {
               if (FileSystemEntity.typeSync(entity.path, followLinks: true) ==
-                  FileSystemEntityType.DIRECTORY) {
+                  FileSystemEntityType.directory) {
                 var fullPath = getFullPath(entity.path).toString();
                 var dirFullPath = getFullPath(dir.path).toString();
                 if (!dirFullPath.startsWith(fullPath)) {

--- a/packages/quiver/lib/src/time/util.dart
+++ b/packages/quiver/lib/src/time/util.dart
@@ -23,7 +23,7 @@ const _daysInMonth = const [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 /// This function assumes the use of the Gregorian calendar or the proleptic
 /// Gregorian calendar.
 int daysInMonth(int year, int month) =>
-    (month == DateTime.FEBRUARY && isLeapYear(year)) ? 29 : _daysInMonth[month];
+    (month == DateTime.february && isLeapYear(year)) ? 29 : _daysInMonth[month];
 
 /// Returns true if [year] is a leap year.
 ///

--- a/packages/quiver/lib/testing/src/async/fake_async.dart
+++ b/packages/quiver/lib/testing/src/async/fake_async.dart
@@ -118,7 +118,7 @@ abstract class FakeAsync {
 }
 
 class _FakeAsync implements FakeAsync {
-  Duration _elapsed = Duration.ZERO;
+  Duration _elapsed = Duration.zero;
   Duration _elapsingTo;
   Queue<Function> _microtasks = new Queue();
   Set<_FakeTimer> _timers = new Set<_FakeTimer>();
@@ -275,7 +275,7 @@ class _FakeTimer implements Timer {
   //     http://www.w3.org/TR/html5/webappapis.html#timer-nesting-level
   // Without some sort of delay this can lead to infinitely looping timers.
   // What do the dart VM and dart2js timers do here?
-  static const _minDuration = Duration.ZERO;
+  static const _minDuration = Duration.zero;
 
   _FakeTimer._(Duration duration, this._callback, this._isPeriodic, this._time)
       : _duration = duration < _minDuration ? _minDuration : duration {

--- a/packages/quiver/test/io_test.dart
+++ b/packages/quiver/test/io_test.dart
@@ -26,7 +26,7 @@ main() {
   group('byteStreamToString', () {
     test('should decode UTF8 text by default', () {
       var string = '箙、靫';
-      var encoded = UTF8.encoder.convert(string);
+      var encoded = utf8.encoder.convert(string);
       var data = [encoded.sublist(0, 3), encoded.sublist(3)];
       var stream = new Stream<List<int>>.fromIterable(data);
       byteStreamToString(stream).then((decoded) {
@@ -36,10 +36,10 @@ main() {
 
     test('should decode text with the specified encoding', () {
       var string = 'blåbærgrød';
-      var encoded = LATIN1.encoder.convert(string);
+      var encoded = latin1.encoder.convert(string);
       var data = [encoded.sublist(0, 4), encoded.sublist(4)];
       var stream = new Stream<List<int>>.fromIterable(data);
-      byteStreamToString(stream, encoding: LATIN1).then((decoded) {
+      byteStreamToString(stream, encoding: latin1).then((decoded) {
         expect(decoded, string);
       });
     });

--- a/packages/quiver/test/testing/async/fake_async_test.dart
+++ b/packages/quiver/test/testing/async/fake_async_test.dart
@@ -273,7 +273,7 @@ main() {
 
         test('should not be additive with elapseBlocking', () {
           new FakeAsync().run((async) {
-            new Timer(Duration.ZERO, () => async.elapseBlocking(elapseBy * 5));
+            new Timer(Duration.zero, () => async.elapseBlocking(elapseBy * 5));
             async.elapse(elapseBy);
             expect(async.getClock(initialTime).now(),
                 initialTime.add(elapseBy * 5));
@@ -310,7 +310,7 @@ main() {
           new FakeAsync().run((async) {
             var callCount = 0;
             new Future(() => callCount++);
-            async.elapse(Duration.ZERO);
+            async.elapse(Duration.zero);
             expect(callCount, 1);
           });
         });

--- a/packages/unittest/CHANGELOG.md
+++ b/packages/unittest/CHANGELOG.md
@@ -1,3 +1,9 @@
+##0.11.8
+
+* Make this branch Dart 2 compatible by using new constant names.
+  The code is no longer Dart 1 compatible, so this version should only be used
+  to run tests that have not yet been converted to using the `test` package.
+
 ##0.11.7
 
 * Add separate methods for `expectAysnc` based on number of callback arguments 

--- a/packages/unittest/lib/html_config.dart
+++ b/packages/unittest/lib/html_config.dart
@@ -84,13 +84,13 @@ String _toHtml(TestCase testCase) {
               ${testCase.description}
             </a>.
           </p>
-          <pre>${HTML_ESCAPE.convert(testCase.message)}</pre>
+          <pre>${htmlEscape.convert(testCase.message)}</pre>
         </td>
       </tr>''';
 
   if (testCase.stackTrace != null) {
     html = '$html<tr><td></td><td colspan="2"><pre>' +
-        HTML_ESCAPE.convert(testCase.stackTrace.toString()) +
+        htmlEscape.convert(testCase.stackTrace.toString()) +
         '</pre></td></tr>';
   }
 

--- a/packages/unittest/lib/html_enhanced_config.dart
+++ b/packages/unittest/lib/html_enhanced_config.dart
@@ -248,11 +248,11 @@ class HtmlEnhancedConfiguration extends SimpleConfiguration {
     }
 
     addRowElement('${test_.id}', '${test_.result.toUpperCase()}',
-        '${test_.description}. ${HTML_ESCAPE.convert(test_.message)}');
+        '${test_.description}. ${htmlEscape.convert(test_.message)}');
 
     if (test_.stackTrace != null) {
       addRowElement('', '',
-          '<pre>${HTML_ESCAPE.convert(test_.stackTrace.toString())}</pre>');
+          '<pre>${htmlEscape.convert(test_.stackTrace.toString())}</pre>');
     }
   }
 

--- a/packages/unittest/lib/src/matcher/core_matchers.dart
+++ b/packages/unittest/lib/src/matcher/core_matchers.dart
@@ -74,13 +74,13 @@ const Matcher isNotNaN = const _IsNotNaN();
 
 class _IsNaN extends Matcher {
   const _IsNaN();
-  bool matches(item, Map matchState) => double.NAN.compareTo(item) == 0;
+  bool matches(item, Map matchState) => double.nan.compareTo(item) == 0;
   Description describe(Description description) => description.add('NaN');
 }
 
 class _IsNotNaN extends Matcher {
   const _IsNotNaN();
-  bool matches(item, Map matchState) => double.NAN.compareTo(item) != 0;
+  bool matches(item, Map matchState) => double.nan.compareTo(item) != 0;
   Description describe(Description description) => description.add('not NaN');
 }
 

--- a/packages/unittest/lib/vm_config.dart
+++ b/packages/unittest/lib/vm_config.dart
@@ -20,7 +20,7 @@ class VMConfiguration extends SimpleConfiguration {
   bool useColor;
 
   VMConfiguration()
-      : useColor = stdioType(stdout) == StdioType.TERMINAL,
+      : useColor = stdioType(stdout) == StdioType.terminal,
         super();
 
   String formatResult(TestCase testCase) {

--- a/packages/unittest/pubspec.yaml
+++ b/packages/unittest/pubspec.yaml
@@ -1,10 +1,10 @@
 name: unittest
-version: 0.11.7
+version: 0.11.8
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/old_unittest
 environment:
-  sdk: '>=1.0.0 <2.0.0'
+  sdk: '>=2.0.0-dev.61.0 <3.0.0'
 dependencies:
   stack_trace: '>=0.9.0 <2.0.0'
 dev_dependencies:

--- a/packages/unittest/test/core_matchers_test.dart
+++ b/packages/unittest/test/core_matchers_test.dart
@@ -33,13 +33,13 @@ void main() {
   });
 
   test('isNaN', () {
-    shouldPass(double.NAN, isNaN);
+    shouldPass(double.nan, isNaN);
     shouldFail(3.1, isNaN, "Expected: NaN Actual: <3.1>");
   });
 
   test('isNotNaN', () {
     shouldPass(3.1, isNotNaN);
-    shouldFail(double.NAN, isNotNaN, "Expected: not NaN Actual: <NaN>");
+    shouldFail(double.nan, isNotNaN, "Expected: not NaN Actual: <NaN>");
   });
 
   test('same', () {


### PR DESCRIPTION
Updates package unittest to the newest version on the 0.11.x branch.

Updates the following packages in-line:
* charted
* quiver

This change affects only this repository, not the original packages.
Before rolling in a new version of any of these packages, ensure that they are using the new constant names.

The quiver package has had a number of breaking changes since it was last rolled into observatory_pub_packages, so I'm taking the path of least resistance by updating the constants here and leaving a roll of the package for later. The newest quiver package has changed the constants, so a later roll will get the correct behavior.

The original charted package has not been updated with the constants yet (https://github.com/google/charted/pull/240), but this repository is at the tip of the original repository, so as soon as this PR lands, any updates will get the correct constants.